### PR TITLE
Add sisjwt_create_token signing method

### DIFF
--- a/lib/sisjwt/rails/verification.rb
+++ b/lib/sisjwt/rails/verification.rb
@@ -46,6 +46,18 @@ module Sisjwt
           raise
         end
 
+        def sisjwt_create_token(payload)
+          signing_options = ::Sisjwt::SisJwtOptions.defaults(mode: :sign).tap do |opts|
+            # We are signing a return request so iss/aud is flipped from how it
+            # is specififed in the controller
+            opts.iss = @@allowed_aud
+            opts.aud = @@allowed_iss
+          end
+
+          sisjwt = ::Sisjwt::SisJwt.new(signing_options, logger: logger)
+          sisjwt.encode(payload)
+        end
+
         protected
 
         def sisjwt_authenticator


### PR DESCRIPTION
This method uses the known context of the specified issuer / audience to create a token.

I opted to not create a method that makes the full API call so that each implementer can handled that requirement themselves.
