### PR TITLE
Bump sisjwt-ruby gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/tractionguest/sisjwt-ruby.git
-  revision: 08a8f739fe8b0cc338fc19470cf0552d3656bda2
+  revision: f01e3e0481d4d99266db0c036aa8c3c491d5355e
   specs:
-    sisjwt (0.3.0)
+    sisjwt (0.3.1)
       activemodel (~> 6.1.7, >= 6.1.7.3)
       activesupport (~> 6.1.7, >= 6.1.7.3)
       aws-sdk-kms (~> 1)
@@ -12,7 +12,7 @@ GIT
 PATH
   remote: .
   specs:
-    sisjwt-rails (0.3.0)
+    sisjwt-rails (0.3.1)
       rails (~> 6.1.7, >= 6.1.7.3)
 
 GEM

--- a/lib/sisjwt/rails/version.rb
+++ b/lib/sisjwt/rails/version.rb
@@ -2,6 +2,6 @@
 
 module Sisjwt
   module Rails
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end


### PR DESCRIPTION
### JIRA: ###

This PR updates the `sisjwt-ruby` gem dependency to the latest version. The new version of this gem includes handling for `Aws::KMS::Errors::NotFoundException` KMS errors.